### PR TITLE
Update CsvParser.php

### DIFF
--- a/src/CsvParser/CsvParser.php
+++ b/src/CsvParser/CsvParser.php
@@ -47,7 +47,7 @@ class CsvParser implements CsvParserInterface
      */
     private function parse(string $content): array
     {
-        $lines = str_getcsv($content, PHP_EOL);
+        $lines = str_getcsv($content, "\n");
 
         foreach ($lines as $index => $line) {
             $lines[$index] = str_getcsv($line);


### PR DESCRIPTION
The delimiter is always "\n". When you're on a windows machine PHP_EOL is "\r\n" and this broke.